### PR TITLE
Release v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+### [Version 1.0.6](https://github.com/CleverTap/clevertap-geofence-ios/releases/tag/1.0.6) (April 18, 2024)
+* Supports the latest CleverTap iOS SDK(6.2.1)
+* Fixes a build error related to privacy manifests when statically linking the SDK using Cocoapods.
+
 ### [Version 1.0.5](https://github.com/CleverTap/clevertap-geofence-ios/releases/tag/1.0.5) (March 20, 2024)
 * Supports the latest CleverTap iOS SDK(6.1.0)
-* Adds NSPrivacy Manifests File
+* Adds XCPrivacy Manifests File
 
 ### [Version 1.0.4](https://github.com/CleverTap/clevertap-geofence-ios/releases/tag/1.0.4) (September 26, 2023)
 * Supports the latest CleverTap iOS SDK via SPM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+### [Version 1.0.6](https://github.com/CleverTap/clevertap-geofence-ios/releases/tag/1.0.6) (March 20, 2024)
+* Fixes a build error related to privacy manifests when statically linking the SDK using Cocoapods.
+
 ### [Version 1.0.5](https://github.com/CleverTap/clevertap-geofence-ios/releases/tag/1.0.5) (March 20, 2024)
 * Supports the latest CleverTap iOS SDK(6.1.0)
 * Adds NSPrivacy Manifests File

--- a/CleverTap-Geofence-SDK.podspec
+++ b/CleverTap-Geofence-SDK.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name                   = 'CleverTap-Geofence-SDK'
-  s.version                = '1.0.5'
+  s.version                = '1.0.6'
   s.summary                = 'CleverTapGeofence provides Geofencing capabilities to CleverTap iOS SDK.'
   s.homepage               = 'https://github.com/CleverTap/clevertap-geofence-ios'
   s.license                = { :type => "MIT" }

--- a/CleverTap-Geofence-SDK.podspec
+++ b/CleverTap-Geofence-SDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.ios.framework          = 'CoreLocation'
   s.ios.deployment_target  = '10.0'
   s.ios.dependency         'CleverTap-iOS-SDK', '>= 3.9'
-  s.resources              = 'Sources/*.xcprivacy'
+  s.resource_bundles       = {'CleverTapGeofence' => ['Sources/*.{xcprivacy}']}
   s.source_files           = 'Sources/*'
   s.swift_version          = '5.1'
   s.requires_arc           = true

--- a/Sources/CleverTapGeofenceUtils.swift
+++ b/Sources/CleverTapGeofenceUtils.swift
@@ -7,7 +7,7 @@ internal struct CleverTapGeofenceUtils {
     
     // MARK: - Static Constants
     
-    internal static let pluginVersion = "10005"
+    internal static let pluginVersion = "10006"
     internal static let geofenceErrorCode = 515
     internal static let defaultDistanceFilter: CLLocationDistance = 200
     internal static let defaultTimeFilter: TimeInterval = 1800


### PR DESCRIPTION
- Supports [CleverTap iOS SDK v6.2.1](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/6.2.1).
- Fixes a build error related to privacy manifests when statically linking the SDK using Cocoapods.